### PR TITLE
feat(orchestrator-workflows): add workflows with Gitlab support

### DIFF
--- a/workflows/application.properties
+++ b/workflows/application.properties
@@ -27,3 +27,6 @@ quarkus.log.category."org.apache.http".level=DEBUG
 
 %dev.quarkus.openapi-generator.githubtwo_yaml.auth.BearerToken.token-propagation=true
 %dev.quarkus.openapi-generator.githubtwo_yaml.auth.BearerToken.header-name=X-Authorization-github-two
+
+%dev.quarkus.openapi-generator.gitlab_yaml.auth.BearerToken.token-propagation=true
+%dev.quarkus.openapi-generator.gitlab_yaml.auth.BearerToken.header-name=X-Authorization-gitlab

--- a/workflows/create-gitlab-pr.sw.yaml
+++ b/workflows/create-gitlab-pr.sw.yaml
@@ -1,0 +1,118 @@
+id: gitlab-pr
+version: "1.0"
+specVersion: "0.8"
+name: "Create GitLab Merge Request"
+description: "This workflow creates a GitLab merge request."
+dataInputSchema: schemas/create-gitlab-pr-input-schema.json
+functions:
+  - name: scafolderMock
+    type: expression
+    operation: |
+      {
+        "files": [
+          {
+            "path": "README.md",
+            "content": "# Hello World"
+          },
+          {
+            "path": "index.js",
+            "content": "console.log('Hello, world!');"
+          }
+        ]
+      }
+  - name: searchProjects
+    operation: specs/gitlab.yaml#searchProjects
+  - name: getProject
+    operation: specs/gitlab.yaml#getProject
+  - name: createBranch
+    operation: specs/gitlab.yaml#createBranch
+  - name: createCommit
+    operation: specs/gitlab.yaml#createCommit
+  - name: createMergeRequest
+    operation: specs/gitlab.yaml#createMergeRequest
+  - name: extractProject
+    type: expression
+    operation: '${ .projectsList | map(select(.path_with_namespace == (.owner + "/" + .repo)))[0] }'
+  - name: successResult
+    type: expression
+    operation: '{
+        "result": {
+          "message": "Merge Request created",
+          "outputs":[
+              {
+                "key": "MR_URL",
+                "value": .mrURL.web_url,
+                "format":"link"
+              }
+            ]
+        }
+      }'
+  - name: sysLog
+    type: custom
+    operation: sysout:INFO
+start: "GetScafolderData"
+states:
+  - name: GetScafolderData
+    type: operation
+    actions:
+      - name: "Get Scafolder data"
+        functionRef:
+          refName: scafolderMock
+        actionDataFilter:
+          toStateData: .scafolderReponse
+    transition: SearchProject
+  - name: SearchProject
+    type: operation
+    actions:
+      - name: SearchProjects
+        functionRef:
+          refName: searchProjects
+          arguments:
+            search: .repo
+            membership: true
+            per_page: 100
+        actionDataFilter:
+          toStateData: .projectsList
+    stateDataFilter:
+      output: '${ . as $state | ($state.projectsList // []) | map(select(.path_with_namespace == ($state.owner + "/" + $state.repo)))[0] as $project | $state + {project: $project} }'
+    transition: CreateBranch
+  - name: CreateBranch
+    type: operation
+    actions:
+      - name: "createBranch"
+        functionRef:
+          refName: createBranch
+          arguments:
+            id: .project.id | tostring
+            branch: .targetBranch
+            ref: .baseBranch
+    transition: CreateCommit
+  - name: CreateCommit
+    type: operation
+    actions:
+      - name: "createCommit"
+        functionRef:
+          refName: createCommit
+          arguments:
+            id: .project.id | tostring
+            branch: .targetBranch
+            commit_message: "Added/Updated multiple files via API"
+            actions: '${ .scafolderReponse.files | map({ "action": "create", "file_path": .path, "content": .content }) }'
+    transition: CreateMR
+  - name: CreateMR
+    type: operation
+    actions:
+      - name: "createMergeRequest"
+        functionRef:
+          refName: createMergeRequest
+          arguments:
+            id: .project.id | tostring
+            source_branch: .targetBranch
+            target_branch: .baseBranch
+            title: "Automated MR"
+        actionDataFilter:
+          toStateData: .mrURL
+      - name: setOutput
+        functionRef:
+          refName: successResult
+    end: true

--- a/workflows/create-pr-universal.sw.yaml
+++ b/workflows/create-pr-universal.sw.yaml
@@ -1,0 +1,295 @@
+id: universal-pr
+version: "1.0"
+specVersion: "0.8"
+name: "Create Universal Pull/Merge Request"
+description: "This workflow creates a pull request (GitHub) or merge request (GitLab) based on approvalTool parameter."
+dataInputSchema: schemas/create-pr-universal-input-schema.json
+functions:
+  # Common functions
+  - name: scafolderMock
+    type: expression
+    operation: |
+      {
+        "files": [
+          {
+            "path": "README.md",
+            "content": "# Hello World"
+          },
+          {
+            "path": "index.js",
+            "content": "console.log('Hello, world!');"
+          }
+        ]
+      }
+  - name: sysLog
+    type: custom
+    operation: sysout:INFO
+  
+  # GitHub functions
+  - name: getBranchSHA
+    operation: specs/github.yaml#getBranchSHA
+  - name: pushCommitBranch
+    operation: specs/github.yaml#updateBranchRef
+  - name: createCommit
+    operation: specs/github.yaml#createCommit
+  - name: createTree
+    operation: specs/github.yaml#createTree
+  - name: createBlob
+    operation: specs/github.yaml#createBlob
+  - name: createBranch
+    operation: specs/github.yaml#createBranch
+  - name: getCommitDetails
+    operation: specs/github.yaml#getCommitDetails
+  - name: createPullRequest
+    operation: specs/github.yaml#createPullRequest
+  - name: createNewBlob
+    type: expression
+    operation: '{"mode": "100644", "path": ($currentFile.path|tostring), "type": "blob", "sha": $WORKFLOW.prevActionResult.sha}'
+  - name: githubSuccessResult
+    type: expression
+    operation: '{
+        "result": {
+          "message": "PR created",
+          "outputs":[
+              {
+                "key": "PR_URL",
+                "value": .prURL.html_url,
+                "format":"link"
+              }
+            ]
+        }
+      }'
+  
+  # GitLab functions
+  - name: searchProjects
+    operation: specs/gitlab.yaml#searchProjects
+  - name: getProject
+    operation: specs/gitlab.yaml#getProject
+  - name: gitlabCreateBranch
+    operation: specs/gitlab.yaml#createBranch
+  - name: gitlabCreateCommit
+    operation: specs/gitlab.yaml#createCommit
+  - name: gitlabCreateMergeRequest
+    operation: specs/gitlab.yaml#createMergeRequest
+  - name: gitlabSuccessResult
+    type: expression
+    operation: '{
+        "result": {
+          "message": "Merge Request created",
+          "outputs":[
+              {
+                "key": "MR_URL",
+                "value": .mrURL.web_url,
+                "format":"link"
+              }
+            ]
+        }
+      }'
+
+start: "GetScafolderData"
+states:
+  - name: GetScafolderData
+    type: operation
+    actions:
+      - name: "Get Scafolder data"
+        functionRef:
+          refName: scafolderMock
+        actionDataFilter:
+          toStateData: .scafolderReponse
+    transition: RouteToProvider
+  
+  - name: RouteToProvider
+    type: switch
+    dataConditions:
+      - condition: '${ .approvalTool == "GIT" }'
+        transition: GitHubCreateBranch
+      - condition: '${ .approvalTool == "GITLAB" }'
+        transition: GitLabSearchProject
+    defaultCondition:
+      transition: ErrorUnknownProvider
+
+  - name: ErrorUnknownProvider
+    type: inject
+    data:
+      error: "Unknown or unsupported approval tool"
+      approvalTool: "${ .approvalTool }"
+    end: true
+  
+  # GitHub workflow states
+  - name: GitHubCreateBranch
+    type: operation
+    actions:
+      - functionRef:
+          refName: sysLog
+          arguments:
+            message: '${ "Creating GitHub branch for " + (.owner | tostring) + "/" + (.repo | tostring) }'
+      - name: "GetHeadSha"
+        functionRef:
+          refName: getBranchSHA
+          arguments:  
+            owner: .owner
+            repo: .repo
+            ref: '"heads/" + .baseBranch'
+        actionDataFilter:
+          toStateData: .latestSHA
+      - name: "createBranch"
+        functionRef:
+          refName: createBranch
+          arguments:  
+            owner: .owner
+            repo: .repo
+            ref: '"refs/heads/" + .targetBranch'
+            sha: .latestSHA.object.sha
+      - name: "getCommitDetails"
+        functionRef:
+          refName: getCommitDetails
+          arguments:  
+            owner: .owner
+            repo: .repo
+            commit_sha: .latestSHA.object.sha
+        actionDataFilter:
+          toStateData: .commit
+    transition: GitHubCreateFiles
+  
+  - name: GitHubCreateFiles
+    type: foreach
+    inputCollection: "${ [.scafolderReponse.files[]] }"
+    iterationParam: currentFile
+    outputCollection: .blobs
+    actions:
+      - name: "createBlob"
+        functionRef:
+          refName: createBlob
+          arguments:  
+            owner: .owner
+            repo: .repo
+            content: ($currentFile.content|tostring)
+            encoding: "utf-8"
+      - name: createNewBlob
+        functionRef:
+          refName: createNewBlob
+    transition: GitHubCreateNewTree
+  
+  - name: GitHubCreateNewTree
+    type: operation
+    actions:
+      - name: "createTree"
+        functionRef:
+          refName: createTree
+          arguments:  
+            owner: .owner
+            repo: .repo
+            base_tree: .commit.tree.sha
+            tree: .blobs
+        actionDataFilter:
+          toStateData: .newTree
+      - name: "createCommit"
+        functionRef:
+          refName: createCommit
+          arguments:  
+            owner: .owner
+            repo: .repo
+            message: "Added/Updated multiple files via API"
+            tree: .newTree.sha
+            parents: [.latestSHA.object.sha]
+        actionDataFilter:
+          toStateData: .newCommit 
+      - name: "push"
+        functionRef:
+          refName: pushCommitBranch
+          arguments:  
+            owner: .owner
+            repo: .repo
+            ref: '"heads/" + .targetBranch'
+            sha: .newCommit.sha 
+            force: false
+    transition: GitHubCreatePR
+  
+  - name: GitHubCreatePR
+    type: operation
+    actions:
+      - name: "createPullRequest"
+        functionRef:
+          refName: createPullRequest
+          arguments:  
+            owner: .owner
+            repo: .repo
+            title: "Automated PR"
+            body: ""
+            head: .targetBranch
+            base: .baseBranch
+        actionDataFilter:
+          toStateData: .prURL   
+      - name: setOutput
+        functionRef:
+          refName: githubSuccessResult
+    end: true
+  
+  # GitLab workflow states
+  - name: GitLabSearchProject
+    type: operation
+    actions:
+      - functionRef:
+          refName: sysLog
+          arguments:
+            message: '${ "Searching GitLab project: " + (.owner | tostring) + "/" + (.repo | tostring) }'
+      - name: SearchProjects
+        functionRef:
+          refName: searchProjects
+          arguments:
+            search: .repo
+            membership: true
+            per_page: 100
+        actionDataFilter:
+          toStateData: .projectsList
+    stateDataFilter:
+      output: '${ . as $state | ($state.projectsList // []) | map(select(.path_with_namespace == ($state.owner + "/" + $state.repo)))[0] as $project | $state + {project: $project} }'
+    transition: GitLabCreateBranch
+  
+  - name: GitLabCreateBranch
+    type: operation
+    actions:
+      - functionRef:
+          refName: sysLog
+          arguments:
+            message: '${ "Creating GitLab branch with project ID: " + (.project.id | tostring) }'
+      - name: "createBranch"
+        functionRef:
+          refName: gitlabCreateBranch
+          arguments:
+            id: .project.id | tostring
+            branch: .targetBranch
+            ref: .baseBranch
+    transition: GitLabCreateCommit
+  
+  - name: GitLabCreateCommit
+    type: operation
+    actions:
+      - name: "createCommit"
+        functionRef:
+          refName: gitlabCreateCommit
+          arguments:
+            id: .project.id | tostring
+            branch: .targetBranch
+            commit_message: "Added/Updated multiple files via API"
+            actions: '${ .scafolderReponse.files | map({ "action": "create", "file_path": .path, "content": .content }) }'
+    transition: GitLabCreateMR
+  
+  - name: GitLabCreateMR
+    type: operation
+    actions:
+      - name: "createMergeRequest"
+        functionRef:
+          refName: gitlabCreateMergeRequest
+          arguments:
+            id: .project.id | tostring
+            source_branch: .targetBranch
+            target_branch: .baseBranch
+            title: "Automated MR"
+        actionDataFilter:
+          toStateData: .mrURL
+      - name: setOutput
+        functionRef:
+          refName: gitlabSuccessResult
+    end: true
+

--- a/workflows/schemas/create-gitlab-pr-input-schema.json
+++ b/workflows/schemas/create-gitlab-pr-input-schema.json
@@ -1,0 +1,43 @@
+{
+  "$id": "classpath:/schemas/create-gitlab-pr-input-schema.json",
+  "title": "Workflow input data for GitLab Merge Request",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "owner": {
+      "title": "GitLab Owner/Group",
+      "description": "The owner or group name (e.g., oandriie)",
+      "type": "string"
+    },
+    "repo": {
+      "title": "GitLab Repository Name",
+      "description": "The repository name (e.g., spring-test)",
+      "type": "string"
+    },
+    "baseBranch": {
+      "title": "Target Branch",
+      "description": "The target branch for the merge request",
+      "type": "string"
+    },
+    "targetBranch": {
+      "title": "Source Branch",
+      "description": "The source branch for the merge request",
+      "type": "string"
+    },
+    "auth": {
+      "title": "Authentication",
+      "type": "string",
+      "ui:widget": "AuthRequester",
+      "ui:props": {
+        "authTokenDescriptors": [
+          {
+            "provider": "gitlab",
+            "scope": "api",
+            "tokenType": "oauth"
+          }
+        ]
+      }
+    }
+  },
+  "required": ["owner", "repo", "baseBranch", "targetBranch"]
+}

--- a/workflows/schemas/create-pr-universal-input-schema.json
+++ b/workflows/schemas/create-pr-universal-input-schema.json
@@ -1,0 +1,55 @@
+{
+  "$id": "classpath:/schemas/create-pr-universal-input-schema.json",
+  "title": "Workflow input data for Universal Pull/Merge Request",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "approvalTool": {
+      "title": "Approval Tool",
+      "description": "The git provider tool to use for creating pull/merge requests",
+      "type": "string",
+      "enum": ["GIT", "GITLAB"]
+    },
+    "owner": {
+      "title": "Owner/Group",
+      "description": "The owner or group name (e.g., oandriie, my-org)",
+      "type": "string"
+    },
+    "repo": {
+      "title": "Repository Name",
+      "description": "The repository name (e.g., spring-test, my-repo)",
+      "type": "string"
+    },
+    "baseBranch": {
+      "title": "Target Branch",
+      "description": "The target branch for the pull/merge request",
+      "type": "string"
+    },
+    "targetBranch": {
+      "title": "Source Branch",
+      "description": "The source branch for the pull/merge request",
+      "type": "string"
+    },
+    "auth": {
+      "title": "Authentication",
+      "type": "string",
+      "ui:widget": "AuthRequester",
+      "ui:props": {
+        "authTokenDescriptors": [
+          {
+            "provider": "github",
+            "scope": "repo",
+            "tokenType": "oauth"
+          },
+          {
+            "provider": "gitlab",
+            "scope": "api",
+            "tokenType": "oauth"
+          }
+        ]
+      }
+    }
+  },
+  "required": ["approvalTool", "owner", "repo", "baseBranch", "targetBranch"]
+}
+

--- a/workflows/specs/gitlab.yaml
+++ b/workflows/specs/gitlab.yaml
@@ -1,0 +1,181 @@
+openapi: 3.0.0
+info:
+  title: GitLab API
+  version: 1.0.0
+servers:
+  - url: https://gitlab.com/api/v4
+security:
+  - BearerToken: []
+paths:
+  /projects:
+    get:
+      summary: List or search projects
+      operationId: searchProjects
+      parameters:
+        - name: search
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: membership
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: simple
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: per_page
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 100
+      responses:
+        '200':
+          description: List of projects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    path_with_namespace:
+                      type: string
+                    default_branch:
+                      type: string
+  /projects/{id}:
+  # It would be nice to use GetProject function to retrieve projectID instead of searchProjects. But...
+  # BUG: OpenAPI generator doesn't handle URL-encoded path parameters correctly
+  # See: https://github.com/OpenAPITools/openapi-generator/issues/10662
+  # It makes double encoding of the path parameter, which is not correct and it also doesn't respect openapi allowReserved field.
+    get:
+      summary: Get a project by ID or path
+      operationId: getProject
+      parameters:
+        - name: id
+          in: path
+          required: true
+          allowReserved: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Project details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  path_with_namespace:
+                    type: string
+                  default_branch:
+                    type: string
+  /projects/{id}/repository/branches:
+    post:
+      summary: Create a new branch
+      operationId: createBranch
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - branch
+                - ref
+              properties:
+                branch:
+                  type: string
+                ref:
+                  type: string
+      responses:
+        '201':
+          description: Branch created
+  /projects/{id}/repository/commits:
+    post:
+      summary: Create a new commit
+      operationId: createCommit
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                branch:
+                  type: string
+                commit_message:
+                  type: string
+                actions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      action:
+                        type: string
+                      file_path:
+                        type: string
+                      content:
+                        type: string
+      responses:
+        '201':
+          description: Commit created
+  /projects/{id}/merge_requests:
+    post:
+      summary: Create a merge request
+      operationId: createMergeRequest
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                source_branch:
+                  type: string
+                target_branch:
+                  type: string
+                title:
+                  type: string
+      responses:
+        '201':
+          description: Merge request created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  web_url:
+                    type: string
+components:
+  securitySchemes:
+    BearerToken:
+      type: http
+      scheme: bearer
+      description: Bearer Token authentication for GitLab API (GitLab supports both Bearer and Private-Token)


### PR DESCRIPTION
# What does this pull request fix

Fixes https://issues.redhat.com/browse/RHIDP-8278

## Demo:

https://drive.google.com/file/d/1_QeQEyPxfLcLDXF-2-DcWa4UxFH3MRpT/view?usp=drive_link

## How to test it.

Enable auto-start for orhestrator plugin in the app-config.yaml:

```yaml

orchestrator:
  sonataFlowService:
    # uncomment the next line to use podman instead of docker
    # runtime: podman
    baseUrl: http://localhost
    port: 8899
    autoStart: true # <---
```

Enable orchestrator API mode for bulk-import plugin:

``` yaml
bulkImport:
  orchestratorWorkflow: universal-pr
  importAPI: orchestrator
```

provide correct Github and Gitlab credentials in the integrations app-config.yaml configuration. Next steps you can  see in the demo.

## What does this pull request do
1. Add orchestrator workflow executions feature for bulk-import plugin.
3. Make playwrite tests stable.

## Related pr with orchestrator workflow, which supports both: github and gitlab:

https://github.com/rhdhorchestrator/backstage-orchestrator-workflows/pull/16